### PR TITLE
Show a message after seeding the datastore

### DIFF
--- a/appEngine-DataStore/labs/hogwarts-query/main.py
+++ b/appEngine-DataStore/labs/hogwarts-query/main.py
@@ -38,7 +38,7 @@ class HouseHandler(webapp2.RequestHandler):
 class LoadDataHandler(webapp2.RequestHandler):
     def get(self):
         seed_data()
-
+        self.response.write('Thank you. The datastore is now seeded.')
 
 app = webapp2.WSGIApplication([
     ('/', MainHandler),

--- a/appEngine-DataStore/labs/hogwarts-query/main.py
+++ b/appEngine-DataStore/labs/hogwarts-query/main.py
@@ -38,7 +38,7 @@ class HouseHandler(webapp2.RequestHandler):
 class LoadDataHandler(webapp2.RequestHandler):
     def get(self):
         seed_data()
-        self.response.write('Thank you. The datastore is now seeded.')
+        self.response.write('Thank you. The Datastore is now seeded.')
 
 app = webapp2.WSGIApplication([
     ('/', MainHandler),


### PR DESCRIPTION
When the students access the `/seed-data` endpoint, they see nothing in the browser. I've added a response so they can have feedback that the datastore was indeed seeded.
